### PR TITLE
Feat(Evaluation): Create product options for evaluation

### DIFF
--- a/database/factories/OptionFactory.php
+++ b/database/factories/OptionFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Keky\Product\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Keky\Product\Models\Option;
+
+class OptionFactory extends Factory
+{
+    protected $model = Option::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => fake()->text(rand(10, 150)),
+        ];
+    }
+}

--- a/database/factories/OptionValueFactory.php
+++ b/database/factories/OptionValueFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Keky\Product\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Keky\Product\Models\Option;
+use Keky\Product\Models\OptionValue;
+
+class OptionValueFactory extends Factory
+{
+    protected $model = OptionValue::class;
+
+    public function definition(): array
+    {
+        return [
+            'value' => fake()->text(rand(20, 150)),
+            'metadata' => rand(0, 1) ? '{"key":"value"}' : null,
+            'option_id' => Option::factory()
+        ];
+    }
+}

--- a/database/factories/OptionValueFactory.php
+++ b/database/factories/OptionValueFactory.php
@@ -15,7 +15,7 @@ class OptionValueFactory extends Factory
         return [
             'value' => fake()->text(rand(20, 150)),
             'metadata' => rand(0, 1) ? '{"key":"value"}' : null,
-            'option_id' => Option::factory()
+            'option_id' => Option::factory(),
         ];
     }
 }

--- a/database/migrations/2024_01_13_163403_create_options_table.php
+++ b/database/migrations/2024_01_13_163403_create_options_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('options', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        Schema::create('product_options', function (Blueprint $table) {
+            $table->unsignedBigInteger('product_id');
+            $table->unsignedBigInteger('option_id');
+
+            $table
+                ->foreign('product_id')
+                ->references('id')
+                ->on('products')
+                ->onDelete('cascade');
+            $table
+                ->foreign('option_id')
+                ->references('id')
+                ->on('options')
+                ->onDelete('cascade');
+            $table->primary(['product_id', 'option_id'], 'product_option_primary');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('options');
+        Schema::dropIfExists('product_options');
+    }
+};

--- a/database/migrations/2024_01_13_163403_create_options_values_table.php
+++ b/database/migrations/2024_01_13_163403_create_options_values_table.php
@@ -20,8 +20,7 @@ return new class extends Migration
             $table
                 ->foreign('option_id')
                 ->references('id')
-                ->on('options')
-            ;
+                ->on('options');
         });
     }
 

--- a/database/migrations/2024_01_13_163403_create_options_values_table.php
+++ b/database/migrations/2024_01_13_163403_create_options_values_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('option_values', function (Blueprint $table) {
+            $table->id();
+            $table->string('value');
+            $table->jsonb('metadata')->nullable();
+            $table->timestamps();
+            $table->unsignedBigInteger('option_id');
+            $table
+                ->foreign('option_id')
+                ->references('id')
+                ->on('options')
+            ;
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('option_values');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Facades\Route;
 use Keky\Product\Http\Controllers\CollectionsController;
+use Keky\Product\Http\Controllers\OptionsController;
+use Keky\Product\Http\Controllers\OptionsValueController;
 use Keky\Product\Http\Controllers\ProductsController;
 
 Route::post('/products', [ProductsController::class, 'store']);
@@ -21,4 +23,22 @@ Route::post('/collections', [CollectionsController::class, 'store']);
 Route::post(
     '/collections/{id}/products',
     [CollectionsController::class, 'attachProducts']
+);
+
+// create option
+Route::post('/options', [OptionsController::class, 'store']);
+
+// create option value
+Route::post('/option-values', [OptionsValueController::class, 'store']);
+
+// attach one product to many options
+Route::post(
+    '/products/{id}/options',
+    [ProductsController::class, 'attachOptions']
+);
+
+// attach one option to many products
+Route::post(
+    '/options/{id}/products',
+    [OptionsController::class, 'attachProducts']
 );

--- a/src/Http/Controllers/OptionsController.php
+++ b/src/Http/Controllers/OptionsController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Keky\Product\Http\Controllers;
+
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Foundation\Application as FoundationApplication;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+use Keky\Product\Http\Requests\OptionProductRequest;
+use Keky\Product\Http\Requests\OptionRequest;
+use Keky\Product\Models\Option;
+use Symfony\Component\HttpFoundation\Response;
+
+class OptionsController extends BaseController
+{
+    use AuthorizesRequests, ValidatesRequests;
+
+    public function __construct(private Option $option)
+    {
+    }
+
+    public function store(OptionRequest $optionRequest)
+    {
+        $option = $this->option->newQuery()->create($optionRequest->all());
+        if (! ($option instanceof Option)) {
+            return response()->json([
+                'success' => 'failed',
+                'message' => 'Internal server error !',
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return response()->json([
+            'success' => 'ok',
+            'data' => $option->toArray(),
+        ], Response::HTTP_CREATED);
+    }
+
+
+    public function attachProducts(OptionProductRequest $request, int $id): FoundationApplication|\Illuminate\Http\Response|Application|ResponseFactory
+    {
+        $option = $this->option->newQuery()->where(['id' => $id])->first();
+        if (! $option) {
+            return response('not_found', 404);
+        }
+        $products = $option->productsOpt()->sync($request->get('product_ids'));
+        if (! empty($products)) {
+            return response('success', 200);
+        }
+
+        return response('internal_server_error', 500);
+    }
+
+}

--- a/src/Http/Controllers/OptionsController.php
+++ b/src/Http/Controllers/OptionsController.php
@@ -37,7 +37,6 @@ class OptionsController extends BaseController
         ], Response::HTTP_CREATED);
     }
 
-
     public function attachProducts(OptionProductRequest $request, int $id): FoundationApplication|\Illuminate\Http\Response|Application|ResponseFactory
     {
         $option = $this->option->newQuery()->where(['id' => $id])->first();
@@ -51,5 +50,4 @@ class OptionsController extends BaseController
 
         return response('internal_server_error', 500);
     }
-
 }

--- a/src/Http/Controllers/OptionsValueController.php
+++ b/src/Http/Controllers/OptionsValueController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Keky\Product\Http\Controllers;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+use Keky\Product\Http\Requests\OptionValueRequest;
+use Keky\Product\Models\OptionValue;
+use Symfony\Component\HttpFoundation\Response;
+
+class OptionsValueController extends BaseController
+{
+    use AuthorizesRequests, ValidatesRequests;
+
+    public function __construct(private OptionValue $optionValue)
+    {
+    }
+
+    public function store(OptionValueRequest $optionValueRequest)
+    {
+        $optionValue = $this->optionValue->newQuery()->create($optionValueRequest->all());
+        if (! ($optionValue instanceof OptionValue)) {
+            return response()->json([
+                'success' => 'failed',
+                'message' => 'Internal server error !',
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        return response()->json([
+            'success' => 'ok',
+            'data' => $optionValue->toArray(),
+        ], Response::HTTP_CREATED);
+    }
+
+}

--- a/src/Http/Controllers/OptionsValueController.php
+++ b/src/Http/Controllers/OptionsValueController.php
@@ -32,5 +32,4 @@ class OptionsValueController extends BaseController
             'data' => $optionValue->toArray(),
         ], Response::HTTP_CREATED);
     }
-
 }

--- a/src/Http/Controllers/ProductsController.php
+++ b/src/Http/Controllers/ProductsController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller as BaseController;
 use Keky\Product\Http\Requests\ProductCollectionRequest;
+use Keky\Product\Http\Requests\ProductOptionRequest;
 use Keky\Product\Http\Requests\ProductRequest;
 use Keky\Product\Models\Product;
 
@@ -93,6 +94,21 @@ class ProductsController extends BaseController
         // Sync product with collections
         $collections = $product->collections()->sync($request->get('collection_ids'));
         if (! empty($collections)) {
+            return response('success', 200);
+        }
+
+        return response('internal_server_error', 500);
+    }
+
+    public function attachOptions(ProductOptionRequest $request, int $id): \Illuminate\Foundation\Application|Response|Application|ResponseFactory
+    {
+        $product = $this->product->newQuery()->where(['id' => $id])->first();
+        if (! $product) {
+            return response('not_found', 404);
+        }
+
+        $options = $product->options()->sync($request->get('option_ids'));
+        if (! empty($options)) {
             return response('success', 200);
         }
 

--- a/src/Http/Requests/OptionProductRequest.php
+++ b/src/Http/Requests/OptionProductRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Keky\Product\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class OptionProductRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'product_ids' => 'required',
+            'product_ids.*' => 'required|exists:products,id',
+        ];
+    }
+
+    public function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response('bad_request', 400)
+        );
+    }
+}

--- a/src/Http/Requests/OptionRequest.php
+++ b/src/Http/Requests/OptionRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Keky\Product\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class OptionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string',
+        ];
+    }
+
+    public function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response('bad_request', 400)
+        );
+    }
+}

--- a/src/Http/Requests/OptionValueRequest.php
+++ b/src/Http/Requests/OptionValueRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Keky\Product\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class OptionValueRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'value' => 'required|string',
+            'metadata' => 'nullable|json',
+        ];
+    }
+
+    public function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response('bad_request', 400)
+        );
+    }
+}

--- a/src/Http/Requests/ProductOptionRequest.php
+++ b/src/Http/Requests/ProductOptionRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Keky\Product\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class ProductOptionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'option_ids' => 'required',
+            'option_ids.*' => 'required|exists:options,id',
+        ];
+    }
+
+    public function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response('bad_request', 400)
+        );
+    }
+}

--- a/src/Models/Option.php
+++ b/src/Models/Option.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Keky\Product\Models;
+
+
+use Keky\Product\Database\Factories\OptionFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Option extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['title'];
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return OptionFactory::new();
+    }
+
+    public function optionValues(): HasMany
+    {
+        return $this->hasMany(OptionValue::class);
+    }
+
+    public function productsOpt(): BelongsToMany
+    {
+        return $this->belongsToMany(Product::class, 'product_options');
+    }
+}

--- a/src/Models/Option.php
+++ b/src/Models/Option.php
@@ -2,13 +2,12 @@
 
 namespace Keky\Product\Models;
 
-
-use Keky\Product\Database\Factories\OptionFactory;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Keky\Product\Database\Factories\OptionFactory;
 
 class Option extends Model
 {

--- a/src/Models/OptionValue.php
+++ b/src/Models/OptionValue.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Keky\Product\Models;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Keky\Product\Database\Factories\OptionValueFactory;
+
+class OptionValue extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'value',
+        'metadata',
+    ];
+
+    public function option(): BelongsTo
+    {
+        return $this->belongsTo(Option::class);
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory(): Factory
+    {
+        return OptionValueFactory::new();
+    }
+}

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -5,6 +5,7 @@ namespace Keky\Product\Models;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Keky\Product\Database\Factories\ProductFactory;
 
 class Product extends Model
@@ -34,8 +35,13 @@ class Product extends Model
         return ProductFactory::new();
     }
 
-    public function collections(): \Illuminate\Database\Eloquent\Relations\BelongsToMany
+    public function collections(): BelongsToMany
     {
         return $this->belongsToMany(Collection::class, 'products_collections');
+    }
+
+    public function options(): BelongsToMany
+    {
+        return $this->belongsToMany(Option::class, 'product_options');
     }
 }

--- a/src/ProductModuleServiceProvider.php
+++ b/src/ProductModuleServiceProvider.php
@@ -22,6 +22,8 @@ class ProductModuleServiceProvider extends PackageServiceProvider
             ->hasMigrations([
                 '2023_12_03_000001_create_products_table',
                 '2023_12_05_000002_create_collections_table',
+                '2024_01_13_163403_create_options_table',
+                '2024_01_13_163403_create_options_values_table',
             ])
             ->runsMigrations()
             ->hasCommand(ProductModuleCommand::class);

--- a/tests/Feature/OptionTest.php
+++ b/tests/Feature/OptionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Keky\Product\Models\Option;
+use Keky\Product\Models\Product;
+
+uses(\Keky\Product\Tests\TestCase::class)->in('Feature');
+
+describe('Basic option tests', function () {
+    it('Count default option', function () {
+        expect(Option::count())->toBe(0);
+    });
+
+    it('Create option by route call', function () {
+        $data = Option::factory()->make()->toArray();
+        $response = $this->post('/options', $data);
+        $response->assertStatus(201);
+
+        $counter = Option::count();
+
+        expect($counter)->toBeInt()->toBeInt()->toBe(1);
+    });
+
+    it('Create option by route call with error', function () {
+        $data = Option::factory()->make()->toArray();
+        $data['title'] = 3000;
+        $response = $this->post('/options', $data);
+        $response->assertBadRequest();
+
+        $counter = Option::count();
+
+        expect($counter)->toBeInt()->toBeInt()->toBe(0);
+    });
+
+    it('First option creation with factories', function () {
+        Option::factory()->create();
+        expect(Option::count())->toBeInt()->toBe(1);
+    });
+});
+
+describe('Attach one option to many products', function () {
+    it('Sync product with fake option id', function () {
+        $products = Product::factory(2)->create();
+
+        $response = $this->post('/options/777/products', [
+            'product_ids' => $products->pluck('id')->all(),
+        ]);
+
+        $response->assertNotFound();
+        expect(Option::count())->toBeInt()->toBe(0);
+    });
+
+    it('Sync option with fake product ids', function () {
+        $option = Option::factory()->create();
+        $response = $this->post('/options/'.$option->id.'/products', [
+            'product_ids' => ['356', '95320'],
+        ]);
+
+        $response->assertBadRequest();
+        expect($option->productsOpt()->count())->toBeInt()->toBe(0);
+    });
+
+    it('Sync option with products', function () {
+        $option = Option::factory()->create();
+        $products = Product::factory(2)->create();
+
+        $response = $this->post('/options/'.$option->id.'/products', [
+            'product_ids' => $products->pluck('id')->all(),
+        ]);
+
+        $response->assertOk();
+        expect($option->productsOpt()->count())->toBeInt()->toBe(2);
+    });
+});
+

--- a/tests/Feature/OptionTest.php
+++ b/tests/Feature/OptionTest.php
@@ -71,4 +71,3 @@ describe('Attach one option to many products', function () {
         expect($option->productsOpt()->count())->toBeInt()->toBe(2);
     });
 });
-

--- a/tests/Feature/OptionlValueTest.php
+++ b/tests/Feature/OptionlValueTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Keky\Product\Models\OptionValue;
+
+uses(\Keky\Product\Tests\TestCase::class)->in('Feature');
+
+describe('Basic optionValue tests', function () {
+    it('Count default OptionValue', function () {
+        expect(OptionValue::count())->toBe(0);
+    });
+
+    it('Create OptionValue by route call with error', function () {
+        $data = OptionValue::factory()->make()->toArray();
+        $data['value'] = 3000;
+        $response = $this->post('/option-values', $data);
+        $response->assertBadRequest();
+
+        $counter = OptionValue::count();
+
+        expect($counter)->toBeInt()->toBeInt()->toBe(0);
+    });
+
+    it('First OptionValue creation with factories', function () {
+        OptionValue::factory()->create();
+        expect(OptionValue::count())->toBeInt()->toBe(1);
+    });
+});

--- a/tests/Feature/ProductTest.php
+++ b/tests/Feature/ProductTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Keky\Product\Models\Collection;
+use Keky\Product\Models\Option;
 use Keky\Product\Models\Product;
 
 uses(\Keky\Product\Tests\TestCase::class)->in('Feature');
@@ -178,3 +179,40 @@ describe('Products with collections', function () {
         expect($product->collections()->count())->toBeInt()->toBe(4);
     });
 });
+
+
+describe('Attach one product to many options', function () {
+    it('Sync option with fake product id', function () {
+        $options = Option::factory(2)->create();
+
+        $response = $this->post('/products/777/options', [
+            'option_ids' => $options->pluck('id')->all(),
+        ]);
+
+        $response->assertNotFound();
+        expect(Product::count())->toBeInt()->toBe(0);
+    });
+
+    it('Sync product options with fake option ids', function () {
+        $product = Product::factory()->create();
+        $response = $this->post('/products/'.$product->id.'/options', [
+            'option_ids' => ['778', '65890'],
+        ]);
+
+        $response->assertBadRequest();
+        expect($product->options()->count())->toBeInt()->toBe(0);
+    });
+
+    it('Sync product with options', function () {
+        $product = Product::factory()->create();
+        $options = Option::factory(2)->create();
+
+        $response = $this->post('/products/'.$product->id.'/options', [
+            'option_ids' => $options->pluck('id')->all(),
+        ]);
+
+        $response->assertOk();
+        expect($product->options()->count())->toBeInt()->toBe(2);
+    });
+});
+

--- a/tests/Feature/ProductTest.php
+++ b/tests/Feature/ProductTest.php
@@ -180,7 +180,6 @@ describe('Products with collections', function () {
     });
 });
 
-
 describe('Attach one product to many options', function () {
     it('Sync option with fake product id', function () {
         $options = Option::factory(2)->create();
@@ -215,4 +214,3 @@ describe('Attach one product to many options', function () {
         expect($product->options()->count())->toBeInt()->toBe(2);
     });
 });
-


### PR DESCRIPTION

## Execution tasks
- Create `options` table with these fields:
  - id: number
  - title: string
- Create `product_options` relation table with these fields:
  - product_id: number
  - option_id: number
- Create `option_values` table with these fields:
  - id: number
  - value: string
  - option_id: number
  - metadata?: json
- Create `Option` model with `products` and `values` relations.
- Create `OptionValue` model with `option` relation.
- Add an API endpoint to create option
- Add an API endpoint to create option value
- Add an API endpoint to attach one product to many options
- Add an API endpoint to attach one option to many products

## Tests


### Option creation
- creation with success and check that option exists in database
- creation fail when request data validation fail
- creation fail when model or builder fail to insert data in database

### Option value creation
- creation with success and check that option exists in database
- creation fail when request data validation fail
- creation fail when model or builder fail to insert data in database

### Attach one option to many products
- creation with success and check that option exists in database
- creation fail when request data validation fail
- creation fail when model or builder fail to insert data in database

### Attach one product to many options
- creation with success and check that option exists in database
- creation fail when request data validation fail
- creation fail when model or builder fail to insert data in database